### PR TITLE
fix(stencil-playwright): addInitScript should be async

### DIFF
--- a/.changeset/strong-penguins-bow.md
+++ b/.changeset/strong-penguins-bow.md
@@ -1,0 +1,5 @@
+---
+"stencil-playwright": patch
+---
+
+page.addInitScript is async in test fixture

--- a/packages/stencil-playwright/src/playwright-page.ts
+++ b/packages/stencil-playwright/src/playwright-page.ts
@@ -33,7 +33,7 @@ export const test = base.extend<CustomFixtures>({
      * can use to determine when it is safe to execute tests
      * on hydrated Stencil components.
      */
-    page.addInitScript(`
+    await page.addInitScript(`
     (function() {
       window.addEventListener('appload', () => {
         window.testAppLoaded = true;


### PR DESCRIPTION
The `.addInitScript` should be async when overriding the test fixture. 