### PR TITLE
idea: support global CSS

### DIFF
--- a/.changeset/spotty-dragons-impress.md
+++ b/.changeset/spotty-dragons-impress.md
@@ -1,0 +1,5 @@
+---
+"stencil-playwright": minor
+---
+
+Adds support for injecting global CSS in setContent via a new `includeGlobalCSS` property in stencil-playwright.json.

--- a/packages/stencil-demo/stencil-playwright.json
+++ b/packages/stencil-demo/stencil-playwright.json
@@ -1,3 +1,4 @@
 {
-  "namespace": "stencil-demo"
+  "namespace": "stencil-demo",
+  "includeGlobalCSS": true
 }

--- a/packages/stencil-playwright/src/page/utils/set-content.ts
+++ b/packages/stencil-playwright/src/page/utils/set-content.ts
@@ -42,7 +42,7 @@ export const setContent = async (page: Page, html: string, testInfo: TestInfo) =
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
         ${appScriptUrl !== undefined ? `<script type="module" src="${baseUrl}${appScriptUrl}"></script>` : ''}
-        ${appGlobalCSSUrl !== undefined ? `<link ref="stylesheet" src="${baseUrl}${appGlobalCSSUrl}"/>` : ''}
+        ${appGlobalCSSUrl !== undefined ? `<link rel="stylesheet" href="${baseUrl}${appGlobalCSSUrl}"/>` : ''}
       </head>
       <body>
         ${html}

--- a/packages/stencil-playwright/src/page/utils/set-content.ts
+++ b/packages/stencil-playwright/src/page/utils/set-content.ts
@@ -25,8 +25,12 @@ export const setContent = async (page: Page, html: string, testInfo: TestInfo) =
   }
 
   let appScriptUrl: string | undefined;
+  let appGlobalCSSUrl: string | undefined;
   if (stencilPlaywrightConfig) {
     appScriptUrl = `/dist/${stencilPlaywrightConfig.namespace}/${stencilPlaywrightConfig.namespace}.esm.js`;
+    if (stencilPlaywrightConfig.includeGlobalCSS) {
+      appGlobalCSSUrl = `/dist/${stencilPlaywrightConfig.namespace}/${stencilPlaywrightConfig.namespace}.css`;
+    }
   }
 
   const dir = testInfo.project?.metadata?.rtl ? 'rtl': 'ltr';
@@ -38,6 +42,7 @@ export const setContent = async (page: Page, html: string, testInfo: TestInfo) =
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
         ${appScriptUrl !== undefined ? `<script type="module" src="${baseUrl}${appScriptUrl}"></script>` : ''}
+        ${appGlobalCSSUrl !== undefined ? `<link ref="stylesheet" src="${baseUrl}${appGlobalCSSUrl}"/>` : ''}
       </head>
       <body>
         ${html}


### PR DESCRIPTION
Would it be possible to support injecting global styles via set content? Our components are basically headless without our design tokens which get loaded externally. 

Instead of adding a new prop to the stencil-playwright.json, we could probably just import the stencil.config and check for `globalStyle`. 