### PR TITLE
fix: remove errors when using in esm

### DIFF
--- a/packages/stencil-playwright/package.json
+++ b/packages/stencil-playwright/package.json
@@ -1,6 +1,7 @@
 {
   "name": "stencil-playwright",
   "version": "0.2.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build && vue-tsc --emitDeclarationOnly",

--- a/packages/stencil-playwright/src/page/utils/set-content.ts
+++ b/packages/stencil-playwright/src/page/utils/set-content.ts
@@ -1,4 +1,5 @@
 import type { Page, TestInfo } from '@playwright/test';
+import { readFileSync } from 'fs';
 
 /**
  * Overwrites the default Playwright page.setContent method.
@@ -19,7 +20,9 @@ export const setContent = async (page: Page, html: string, testInfo: TestInfo) =
   let stencilPlaywrightConfig: any;
 
   try {
-    stencilPlaywrightConfig = require(`${process.cwd()}/stencil-playwright.json`);
+    stencilPlaywrightConfig = JSON.parse(
+      readFileSync(`${process.cwd()}/stencil-playwright.json`, "utf-8")
+    );
   } catch (ex) {
     console.error('Error loading stencil-playwright.json', ex);
   }


### PR DESCRIPTION
Hey, I experienced the two errors shown in the screenshots below when using `stencil-playwright` in an esm project (with `"type": "module"` set in my package.json.

This PR fixes those issues.
Note: `require` is only defined in commonjs, not esm. So I changed it to use native node `readFileSync` instead.

![Screenshot 2023-06-16 at 16 03 33](https://github.com/sean-perkins/stencil-playwright/assets/67898185/93ff8de0-e2dc-49b8-b335-30efe73b0ca4)
![Screenshot 2023-06-16 at 16 02 54](https://github.com/sean-perkins/stencil-playwright/assets/67898185/eb71fd30-47f2-424b-8966-d9e4e3c74423)
